### PR TITLE
reparse individual non-parsed words after full sentence

### DIFF
--- a/src/rtx_decomp.cc
+++ b/src/rtx_decomp.cc
@@ -12,13 +12,13 @@
 
 void endProgram(char *name)
 {
-  cout << basename(name) << ": decompile a transfer bytecode file" << endl;
-  cout << "USAGE: " << basename(name) << " [ -h ] [input_file [output_file]]" << endl;
-  cout << "Options:" << endl;
+  std::cout << basename(name) << ": decompile a transfer bytecode file" << std::endl;
+  std::cout << "USAGE: " << basename(name) << " [ -h ] [input_file [output_file]]" << std::endl;
+  std::cout << "Options:" << std::endl;
 #if HAVE_GETOPT_LONG
-  cout << "  -h, --help: show this help" << endl;
+  std::cout << "  -h, --help: show this help" << std::endl;
 #else
-  cout << "  -h: show this help" << endl;
+  std::cout << "  -h: show this help" << std::endl;
 #endif
   exit(EXIT_FAILURE);
 }
@@ -263,7 +263,7 @@ int main(int argc, char *argv[])
     in = fopen(argv[optind], "rb");
     if(in == NULL)
     {
-      cerr << "Error: could not open file " << argv[optind] << " for reading." << endl;
+      std::cerr << "Error: could not open file " << argv[optind] << " for reading." << std::endl;
       exit(EXIT_FAILURE);
     }
   }
@@ -272,7 +272,7 @@ int main(int argc, char *argv[])
     out = u_fopen(argv[optind+1], "wb", NULL, NULL);
     if(out == NULL)
     {
-      cerr << "Error: could not open file " << argv[optind+1] << " for writing." << endl;
+      std::cerr << "Error: could not open file " << argv[optind+1] << " for writing." << std::endl;
       exit(EXIT_FAILURE);
     }
   }

--- a/tests/Reparse.input
+++ b/tests/Reparse.input
@@ -1,0 +1,1 @@
+^ja<cnjcoo>/ja<cnjcoo>$ ^Jämtlánda<np><top><sg><gen><@→N>/Jämtlánnda<np><top><sg><gen><@→N>$ ^regiovdna<n><sem_plc><sg><gen><@→P>/regiåvnnå<n><sem_plc><sg><gen><@→P>$ ^dáfus<post><@ADVL>/gáktuj<post><@ADVL>$^.<sent>/.<sent>$

--- a/tests/Reparse.output
+++ b/tests/Reparse.output
@@ -1,0 +1,1 @@
+^ja<cnjcoo>$ ^Jämtlánnda<np><sg><gen>$ ^regiåvnnå<n><sg><gen>$ ^gáktuj<post>$^.<sent>$

--- a/tests/Reparse.rtx
+++ b/tests/Reparse.rtx
@@ -1,0 +1,42 @@
+!!!!!!!!!!!!!!!
+!!  ATTRIBUTE CATEGORIES
+!!!!!!!!!!!!!!!
+
+function = "@→N" "@→P" "@ADVL" ;
+number = sg du pl ;
+case = acc nom gen loc ine ela com ess ill ;
+
+!!!!!!!!!!!!!!!
+!! OUTPUT PATTERNS
+!!!!!!!!!!!!!!!
+
+NP: _.number.case.function ;
+PP: _ ;
+
+Name: _.number.case.function ;
+N: _.number.case.function ;
+n: <n>.number.case;
+
+post: _ ;
+
+np: <np>.number.case ;
+
+
+!!!!!!!!!!!!!!!
+!! REDUCTION RULES
+!!!!!!!!!!!!!!!
+
+N ->    "N:n"  %n { %1 } ;
+
+Name ->   "N:np"     %np { %1 }
+	| "NP:N Name" N %Name {1 _ %2 } !gonagas Harald
+	| "NP:N Name" np %Name {1 _ %2 } !
+	| "NP:N Name" Name %N {1 _ %2 } ! ! Verdens Gang aviisii
+	;
+
+NP -> "NP: N" %N { %1 } ;
+
+
+PP -> "PP N post" N %post { 1 _ %2 }
+    | "lone post"   %post { 1 }
+    ;

--- a/tests/build_tests.py
+++ b/tests/build_tests.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 f = open('run_tests.py', 'w')
 f.write('''#!/usr/bin/env python3
+
+#####################################################
+### run_tests.py IS A GENERATED FILE, DO NOT EDIT ###
+#####################################################
+
 import subprocess, unittest
 
 class CompilerTest:


### PR DESCRIPTION
as noted in https://github.com/apertium/apertium-recursive/issues/80#issuecomment-1691484763 this tries to do a reparse of single, unparsed words after full parse. 

It seems to fix things in corpus runs. 

Could it break anything @mr-martian ?